### PR TITLE
Install Prismjs from GitHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12826,9 +12826,8 @@
       }
     },
     "prismjs": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
-      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+      "version": "git+https://github.com/PrismJS/prism.git#217a6ea4262083aad1d8dd140475ea7ff64ce2d8",
+      "from": "git+https://github.com/PrismJS/prism.git",
       "requires": {
         "clipboard": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gatsby-transformer-remark": "^2.1.17",
     "gatsby-transformer-sharp": "^2.1.9",
     "inter-ui": "^3.2.0",
-    "prismjs": "^1.15.0",
+    "prismjs": "git+https://github.com/PrismJS/prism.git",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",


### PR DESCRIPTION
I've been wondering why `hcl` code highlighting hasn't been working, despite it definitely being added in Prismjs. Turns out the package hasn't cut a new release in a few months - they're already aware (https://github.com/PrismJS/prism/issues/1713), so in the meantime this PR installs Prismjs directly from [the repo](https://github.com/PrismJS/prism).