### PR TITLE
Use custom serializer for RSS plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -75,7 +75,46 @@ module.exports = {
       }
     },
     `gatsby-plugin-catch-links`,
-    `gatsby-plugin-feed`,
+    {
+      resolve: `gatsby-plugin-feed`,
+      options: {
+        feeds: [
+          {
+            serialize({ query: { site, allMarkdownRemark } }) {
+              return allMarkdownRemark.edges.map(edge => ({
+                ...edge.node.frontmatter,
+                description: edge.node.frontmatter.spoiler,
+                date: edge.node.frontmatter.date,
+                url: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                custom_elements: [{ 'content:encoded': edge.node.html }]
+              }))
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  limit: 1000,
+                  sort: { order: DESC, fields: [frontmatter___date] }
+                ) {
+                  edges {
+                    node {
+                      html
+                      fields { slug }
+                      frontmatter {
+                        title
+                        date
+                        spoiler
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/rss.xml'
+          }
+        ]
+      }
+    },
     `gatsby-plugin-netlify`
   ]
 }


### PR DESCRIPTION
This PR customizes usage of the `gatsby-plugin-feed` library to swap the `<description>` XML tag's contents. It _was_ an excerpt of the contents of the post - now it'll be the `spoiler` front matter attribute which is more consistent and controllable.